### PR TITLE
fixed Uncaught TypeError: undefined is not a function for $('#cropbox').Jcrop in crop.html.erb file.

### DIFF
--- a/lib/generators/spree_image_cropper/install/install_generator.rb
+++ b/lib/generators/spree_image_cropper/install/install_generator.rb
@@ -2,13 +2,13 @@ module SpreeImageCropper
   module Generators
     class InstallGenerator < Rails::Generators::Base
 
-      def add_javascripts
-        append_file 'app/assets/javascripts/application.js', "//= require spree/backend/spree_image_cropper\n"
-      end
+      def add_javascripts 
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_image_cropper\n" 
+      end 
 
-      def add_stylesheets
-        inject_into_file 'app/assets/stylesheets/application.css', " *= require spree/backend/spree_image_cropper\n", before: /\*\//, verbose: true
-      end
+      def add_stylesheets 
+        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/spree_image_cropper\n", before: /\*\//, verbose: true 
+      end 
 
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_image_cropper'


### PR DESCRIPTION
Uncaught TypeError: undefined is not a function for $('#cropbox').Jcrop in crop.html.erb file.